### PR TITLE
fix: update base name

### DIFF
--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -43,5 +43,5 @@ export default defineConfig({
         prevPageText: '上一篇(prevPageText) ⬅️',
         nextPageText: '下一篇(nextPageText) ➡️',
     },
-    base: '/develop_runtime/'
+    base: '/DEVELOP_RUNTIME/'
 })


### PR DESCRIPTION
* update `rspress.config.ts` config, replace the base name: 'develop_runtime' --> `DEVELOP_RUNTIME`